### PR TITLE
Asio stop

### DIFF
--- a/include/dct/schema/cert_to_schema.hpp
+++ b/include/dct/schema/cert_to_schema.hpp
@@ -32,7 +32,7 @@
 // return the binary schema associated with certificate 'cert'
 // It's assumed that the cert signature has been validated and
 // the cert name checked for conformance to schema conventions.
-bSchema certToSchema(const dctCert& cert, thumbPrint& tp) {
+inline bSchema certToSchema(const dctCert& cert, thumbPrint& tp) {
     std::istringstream is(std::string(cert.content().toSv()), std::ios::binary);
     auto bs = rdSchema(is).read();
     bs.schemaTP_.insert(bs.schemaTP_.begin(), tp.begin(), tp.end());

--- a/include/dct/schema/dct_model.hpp
+++ b/include/dct/schema/dct_model.hpp
@@ -234,6 +234,7 @@ struct DCTmodel {
     // export the syncps API
  
     auto run() { m_sync.run(); };
+    auto stop() { m_sync.stop(); }
 
     auto& subscribe(const Name& topic, SubCb&& cb) {
         m_sync.subscribe(crPrefix{topic}, std::move(cb));

--- a/include/dct/schema/rpacket.hpp
+++ b/include/dct/schema/rpacket.hpp
@@ -106,8 +106,8 @@ struct rPrefix : tlvParser {
 };
 
 // name ordering is lexicographic
-auto rName::operator<=>(const rName& rhs) const noexcept { return rPrefix(*this) <=> rPrefix(rhs); }
-bool rName::isPrefix(const rName& nm) const noexcept { return rPrefix(*this).isPrefix(rPrefix(nm)); }
+inline auto rName::operator<=>(const rName& rhs) const noexcept { return rPrefix(*this) <=> rPrefix(rhs); }
+inline bool rName::isPrefix(const rName& nm) const noexcept { return rPrefix(*this).isPrefix(rPrefix(nm)); }
 
 template<> struct std::hash<rName> {
     size_t operator()(const rName& c) const noexcept { return std::hash<tlvParser>{}(c); }

--- a/include/dct/shims/mbps.hpp
+++ b/include/dct/shims/mbps.hpp
@@ -97,6 +97,7 @@ struct mbps
     mbps(std::string_view bootstrap) : mbps(bootstrap, "")  { }
 
     void run() { m_pb.run(); }
+    void stop() { m_pb.stop(); }
     const auto& pubPrefix() const noexcept { return m_pubpre; }
 
     /* relies on trust schema using mbps conventions of collecting all the signing chain

--- a/include/dct/syncps/syncps.hpp
+++ b/include/dct/syncps/syncps.hpp
@@ -496,9 +496,14 @@ struct SyncPS {
     auto& autoStart(bool yesNo) { autoStart_ = yesNo; return *this; }
 
     /**
-     * @brief start running the event manager main loop (usually doesn't return)
+     * @brief start running the event manager main loop (use stop() to return)
      */
     void run() { getDefaultIoContext().run(); }
+
+    /**
+     * @brief stop the running the event manager main loop
+     */
+    void stop() { getDefaultIoContext().stop(); }
 
     /**
      * @brief methods to change callbacks


### PR DESCRIPTION
This pull request exposes Boost's Asio stop() function. This function is used to break out of the run() function. This capability is needed in order to cleanly exit a thread which is executing the mbps shim run() function.

Additionally, this pull request adds inline to three functions which previously resulted in multiple definition linker errors when the headers were included by multiple files in a client project.