### PR TITLE
fix(tcp): reading offset calculation

### DIFF
--- a/include/dct/face/transport.hpp
+++ b/include/dct/face/transport.hpp
@@ -456,8 +456,8 @@ struct TransportTcp : Transport {
                 if (totlen > len) {
                     // copy down any leftover tlv frag
                     if (len > 0) std::memmove(rbuf_.data(), rbuf_.data() + totlen - len, len);
-                    roff_ = len;
                 }
+                roff_ = len;
                 issueRead();
             });
     }


### PR DESCRIPTION
Since we start reading into the buffer at roff_, it needs to be updated every time an incomplete packet is read, not just when an entire packet was read. This bug causes the TCP connection to reset every time an incomplete packet is read, since the TLV parsing subsequently fails.