### PR TITLE
fix(shim): remove unused getopt header

### DIFF
--- a/include/dct/shims/mbps.hpp
+++ b/include/dct/shims/mbps.hpp
@@ -27,7 +27,6 @@
 #include <algorithm>
 #include <bitset>
 #include <functional>
-#include <getopt.h>
 #include <iostream>
 #include <random>
 #include <stdexcept>

--- a/include/dct/shims/ptps.hpp
+++ b/include/dct/shims/ptps.hpp
@@ -27,7 +27,6 @@
 #include <algorithm>
 #include <bitset>
 #include <functional>
-#include <getopt.h>
 #include <iostream>
 #include <random>
 #include <stdexcept>


### PR DESCRIPTION
The DCT _library_ doesn't need these, and it breaks build on Windows.